### PR TITLE
added methods to add and remove labels with an Object tag

### DIFF
--- a/library/src/main/java/com/dpizarro/autolabel/library/AutoLabelUI.java
+++ b/library/src/main/java/com/dpizarro/autolabel/library/AutoLabelUI.java
@@ -1,7 +1,5 @@
 package com.dpizarro.autolabel.library;
 
-import com.dpizarro.autolabeluilibrary.R;
-
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -10,7 +8,7 @@ import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.ViewGroup;
-
+import com.dpizarro.autolabeluilibrary.R;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -114,6 +112,37 @@ public class AutoLabelUI extends AutoViewGroup implements Label.OnClickCrossList
             }
         }
 
+    }
+
+    /**
+     * Method to add a Label with a custom Object tag.
+     *
+     * @param textlabel is the text of the label added using a LIST.
+     * @param tag is the tag used to retrieve the label for later use
+     */
+    public boolean addLabel(String textlabel, Object tag) {
+        if (!checkLabelsCompleted()) {
+            Label label = new Label(getContext(), mTextSize, mIconCross, mShowCross, mTextColor,
+                mBackgroundResource, mLabelsClickables, mLabelPadding);
+            label.setLayoutParams(new LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT));
+            label.setText(textlabel);
+            label.setTag(tag);
+            label.setOnClickCrossListener(this);
+            label.setOnLabelClickListener(this);
+
+            increaseLabelsCounter();
+            addView(label);
+            requestLayout();
+
+            return true;
+        }
+
+        if (listenerOnLabelsCompleted != null) {
+            listenerOnLabelsCompleted.onLabelsCompleted();
+            ;
+        }
+        return false;
     }
 
     /**
@@ -230,6 +259,28 @@ public class AutoLabelUI extends AutoViewGroup implements Label.OnClickCrossList
         if (listenerOnLabelClick != null) {
             listenerOnLabelClick.onClickLabel(label);
         }
+    }
+
+    /**
+     * Method to remove a label using a list
+     *
+     * @param tag the object used as a tag when creating the label. See {@link #addLabel(String,
+     * Object)} method
+     */
+    public boolean removeLabel(Object tag) {
+        Label label = (Label) findViewWithTag(tag);
+        if (label != null) {
+            removeView(label);
+            decreaseLabelsCounter();
+            if (getLabelsCounter() == EMPTY) {
+                if (listenerOnLabelsEmpty != null) {
+                    listenerOnLabelsEmpty.onLabelsEmpty();
+                }
+            }
+            requestLayout();
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
I've encountered some cases during the development of my app where it is not enough to add a label using a String or index tag, like when labels can be of the same text representation but represent different object in a selection, or when you're trying to remove a label that corresponds to a certain checked item in your list, but the text on the label is not unique. This pull request solves that issue by being able to add a label with an Object as a tag. This can be useful when you want to pass your own model object as a tag; just make sure that your object properly overrides the equals() method so the removeLabel(Object tag) method can properly remove the corresponding label with the given tag.
